### PR TITLE
add Firefox compatibility

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -169,13 +169,13 @@ function setKeys(event) {
 // EVENT LISTENERS
 
 document.querySelectorAll('.number').forEach(num => {
-  num.addEventListener('click', () => {
+  num.addEventListener('click', (event) => {
     selectNumber(event.target.id);
   });
 });
 
 document.querySelectorAll('.operator').forEach(operator => {
-  operator.addEventListener('click', () => {
+  operator.addEventListener('click', (event) => {
     selectOperator(event.target.id);
   });
 });


### PR DESCRIPTION
Hey! I suppose you haven't tried to run your code on different browsers. Currently it works on Chrome but not on Firefox. That happens to everyone :)

When adding an event listener in Firefox without the help of an external library like jQuery, you need to declare the event as a parameter in the handler, or else your code won't work. And it makes sense to add it as a parameter, when you think about it. You can read here to learn more about this; https://stackoverflow.com/questions/20522887/referenceerror-event-is-not-defined-error-in-firefox